### PR TITLE
Adaptions to build executables for Windows and macOS via GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -r requirements-build.txt
 
       - name: Update version numbers
         shell: python
@@ -85,8 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -r requirements-build.txt
 
       - name: Update version numbers
         shell: python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,16 @@ jobs:
       - name: Build Windows executable
         run: python -m PyInstaller --clean p2d.spec
 
+      - name: Debug - List dist directory
+        shell: cmd
+        run: |
+          dir dist /s
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: p2d-windows
-          path: dist/p2d.exe
+          path: dist/p2d/**/*
 
   build-macos:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,6 @@ jobs:
       - name: Build Windows executable
         run: python -m PyInstaller --clean p2d.spec
 
-      - name: Debug - List dist directory
-        shell: cmd
-        run: |
-          dir dist /s
-
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,37 @@ stop
 - Regular expressions for parsing
 - XML libraries for Draw.io generation
 
+## 📦 Executables
+
+The project provides pre-built executables for both Windows and macOS through GitHub Actions. These executables are automatically built when:
+- A new version tag is pushed (e.g., `v1.0.0`)
+- The workflow is manually triggered via GitHub Actions UI
+
+### Download Executables
+
+1. Go to the [Releases](https://github.com/doubleSlashde/plantuml2drawio/releases) page to download the latest release
+2. Or download the latest build artifacts from the [Actions](https://github.com/doubleSlashde/plantuml2drawio/actions) page:
+   - `p2d-windows` - Windows executable with all dependencies
+   - `p2d-macos` - macOS application bundle (.app)
+
+### Building Executables Locally
+
+You can build the executables locally using PyInstaller. You only need the runtime dependencies and PyInstaller:
+
+```bash
+# Install build requirements (includes runtime dependencies)
+pip install -r requirements-build.txt
+
+# Build executable
+python -m PyInstaller --clean p2d.spec
+```
+
+The built executables will be available in the `dist` directory:
+- Windows: `dist/p2d/p2d.exe` (with dependencies)
+- macOS: `dist/p2d.app` (application bundle)
+
+Note: The final executable will include all necessary runtime dependencies, so end users don't need to install Python or any requirements.
+
 ## 🗺️ Roadmap
 
 - [x] Support for activity diagrams

--- a/p2d.spec
+++ b/p2d.spec
@@ -3,10 +3,10 @@
 
 a = Analysis(
     ['src/plantuml2drawio/app.py'],
-    pathex=[],
+    pathex=['src'],
     binaries=[],
     datas=[],
-    hiddenimports=[],
+    hiddenimports=['plantuml2drawio'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -19,16 +19,13 @@ pyz = PYZ(a.pure)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.datas,
     [],
+    exclude_binaries=True,
     name='p2d',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    upx_exclude=[],
-    runtime_tmpdir=None,
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -37,8 +34,20 @@ exe = EXE(
     entitlements_file=None,
     icon=['resources/icons/p2d_icon.icns'],
 )
-app = BUNDLE(
+
+coll = COLLECT(
     exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='p2d'
+)
+
+app = BUNDLE(
+    coll,
     name='p2d.app',
     icon='resources/icons/p2d_icon.icns',
     bundle_identifier=None,

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+# Building
+pyinstaller>=6.4.0 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,11 +17,3 @@ pre-commit>=3.6.2
 # Documentation
 sphinx>=7.2.6
 sphinx-rtd-theme>=2.0.0
-
-from plantuml2drawio.logging_config import setup_logging
-
-setup_logging(
-    log_level="DEBUG",
-    log_file="app.log",
-    log_format="%(asctime)s - %(levelname)s - %(message)s"
-)


### PR DESCRIPTION
- Added description for GitHub Action in README
- Optimized p2d.spec file to be able to build executables
- Tested on macOS

Test on windows is currently ongoing (i will contact a test person with a Windows PC). If successful we can merge.